### PR TITLE
hashibot: Test more advanced regexp for regexp_issue_labeler_v2

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -8,5 +8,16 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
     "service/acmpca" = [
       "aws_acmpca_",
     ],
+    "service/ec2" = [
+      "aws_route(\"|`|$)",
+    ],
+    "service/route53" = [
+      # Catch aws_route53_XXX but not aws_route53_resolver_
+      # Golang regexp does not support negative lookaheads
+      "aws_route53_([^r]|r[^e]|re[^s])",
+    ],
+    "service/route53resolver" = [
+      "aws_route53_resolver_",
+    ],
   }
 }


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
